### PR TITLE
feat: Use AWS SDK to invalidate using pulumi beforeExit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Pulumi.
 
 ### Setup
 
+1. Ensure that the [Pulumi CLI](https://www.pulumi.com/docs/install/) is installed.
 1. Create a SvelteKit project "my-app" - `npm create svelte@latest my-app`
 1. `cd my-app`
 1. `npm install`

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "vitest": "^1.6.0"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudfront": "^3.577.0",
     "@pulumi/aws": "^6.36.0",
     "@pulumi/command": "^0.10.0",
     "@pulumi/pulumi": "^3.116.1",

--- a/stacks/server/index.ts
+++ b/stacks/server/index.ts
@@ -4,14 +4,14 @@ import { getLambdaRole, buildLambda } from './resources.js'
 import { getEnvironment } from '../utils.js'
 
 const pulumiConfig = new pulumi.Config()
-const projectPath = pulumiConfig.get('projectPath')
-const serverPath = pulumiConfig.get('serverPath')
-const optionsPath = pulumiConfig.get('optionsPath')
-const memorySizeStr = pulumiConfig.get('memorySize')
+const projectPath = pulumiConfig.require('projectPath')
+const serverPath = pulumiConfig.require('serverPath')
+const optionsPath = pulumiConfig.require('optionsPath')
+const memorySizeStr = pulumiConfig.require('memorySize')
 const allowedOriginsStr = pulumiConfig.get('allowedOrigins')
 let serverInvokeMode = pulumiConfig.get('serverInvokeMode')
 
-const memorySize = Number(memorySizeStr!)
+const memorySize = Number(memorySizeStr)
 
 let optionsEnv: any = {}
 
@@ -24,12 +24,12 @@ if (!serverInvokeMode) {
 }
 
 const iamForLambda = getLambdaRole()
-const environment = getEnvironment(projectPath!)
+const environment = getEnvironment(projectPath)
 
 const serverURL = buildLambda(
   'LambdaServer',
   iamForLambda,
-  serverPath!,
+  serverPath,
   environment.parsed,
   memorySize,
   serverInvokeMode,
@@ -38,7 +38,7 @@ const serverURL = buildLambda(
 const optionsURL = buildLambda(
   'LambdaOptions',
   iamForLambda,
-  optionsPath!,
+  optionsPath,
   optionsEnv,
 )
 

--- a/tests/stacks.main.resources.test.ts
+++ b/tests/stacks.main.resources.test.ts
@@ -14,6 +14,18 @@ describe('stacks/main/resources.ts', () => {
     vi.resetModules()
     mocks = new MyMocks()
     pulumi.runtime.setMocks(mocks)
+
+    // @ts-ignore
+    pulumi.Config = vi.fn(() => {
+      return {
+        require: vi.fn((x) => {
+          if (x === 'aws:region') {
+            return '{"aws:region": "mock"}'
+          }
+        }),
+      }
+    })
+
     infra = await import('../stacks/main/resources.js')
   })
 

--- a/tests/stacks.server.index.test.ts
+++ b/tests/stacks.server.index.test.ts
@@ -46,11 +46,14 @@ describe('stacks/server/index.ts', () => {
     pulumi.Config = vi.fn(() => {
       return {
         get: vi.fn((x) => {
-          if (x === 'projectPath') {
-            return tmpDir
-          }
           if (x === 'allowedOrigins') {
             return '[example.com]'
+          }
+          return ''
+        }),
+        require: vi.fn((x) => {
+          if (x === 'projectPath') {
+            return tmpDir
           }
           if (x === 'memorySize') {
             return '256'
@@ -107,6 +110,9 @@ describe('stacks/server/index.ts', () => {
     pulumi.Config = vi.fn(() => {
       return {
         get: vi.fn((x) => {
+          return ''
+        }),
+        require: vi.fn((x) => {
           if (x === 'projectPath') {
             return tmpDir
           }


### PR DESCRIPTION
Changes:

+ Call CloudFront invalidation using the AWS SDK triggered by pulumi's beforeExit hook. See https://www.pulumi.com/blog/next-level-iac-pulumi-runtime-logic/
+ Drops the requirement for the AWS CLI to be installed
+ README explicitly states that the Pulumi CLI should be installed