### PR TITLE
feat: use Vite for env variable loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ Values can be added to the `.env` file or defined as environment
 variables. If environment variables are defined they will overwrite the values
 in the .env file.
 
+See [$env/static/private](https://kit.svelte.dev/docs/modules#$env-static-private)
+in the SvelteKit documentation for further details.
+
 ## Destroy Command
 
 A script is provided to destroy the infrastructure, with the following

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@types/folder-hash": "^4.0.4",
-    "@types/lodash": "^4.17.1",
     "@types/mime-types": "^2.1.4",
     "@types/minimist": "^1.2.5",
     "@types/node": "20.12.12",
@@ -57,8 +56,6 @@
     "@aws-sdk/client-cloudfront": "^3.577.0",
     "@pulumi/aws": "^6.36.0",
     "@pulumi/pulumi": "^3.116.1",
-    "dotenv": "^16.4.5",
-    "lodash": "^4.17.21",
     "mime-types": "^2.1.35",
     "sveltekit-adapter-aws-base": "^3.0.1",
     "yargs": "^17.7.2"

--- a/stacks/server/index.ts
+++ b/stacks/server/index.ts
@@ -1,10 +1,8 @@
 import * as pulumi from '@pulumi/pulumi'
 
 import { getLambdaRole, buildLambda } from './resources.js'
-import { getEnvironment } from '../utils.js'
 
 const pulumiConfig = new pulumi.Config()
-const projectPath = pulumiConfig.require('projectPath')
 const serverPath = pulumiConfig.require('serverPath')
 const optionsPath = pulumiConfig.require('optionsPath')
 const memorySizeStr = pulumiConfig.require('memorySize')
@@ -24,13 +22,12 @@ if (!serverInvokeMode) {
 }
 
 const iamForLambda = getLambdaRole()
-const environment = getEnvironment(projectPath)
 
 const serverURL = buildLambda(
   'LambdaServer',
   iamForLambda,
   serverPath,
-  environment.parsed,
+  undefined,
   memorySize,
   serverInvokeMode,
 )

--- a/stacks/utils.ts
+++ b/stacks/utils.ts
@@ -1,18 +1,3 @@
-import * as path from 'path'
-
-import { config, DotenvConfigOutput } from 'dotenv'
-import { assign, keys, pick } from 'lodash'
-
-export function getEnvironment(projectPath: string): DotenvConfigOutput {
-  const dotenv = config({ path: path.join(projectPath, '.env') })
-  const parsed = assign(
-    {},
-    dotenv.parsed,
-    pick(process.env, keys(dotenv.parsed))
-  )
-  return { parsed: parsed } as DotenvConfigOutput
-}
-
 export class NameRegister {
   private static singleton: NameRegister
   private _names: string[] = []

--- a/tests/stacks.server.index.test.ts
+++ b/tests/stacks.server.index.test.ts
@@ -68,7 +68,7 @@ describe('stacks/server/index.ts', () => {
     expect(resources.getLambdaRole).toHaveBeenCalledTimes(1)
     expect(resources.buildLambda).toHaveBeenCalledTimes(2)
 
-    expect(mockBuildLambda.mock.calls[0][3]).toStrictEqual({ MOCK: '' })
+    expect(mockBuildLambda.mock.calls[0][3]).toStrictEqual(undefined)
     expect(mockBuildLambda.mock.calls[0][4]).toStrictEqual(256)
     expect(mockBuildLambda.mock.calls[1][3]).toStrictEqual({
       ALLOWED_ORIGINS: '[example.com]',

--- a/tests/stacks.utils.test.ts
+++ b/tests/stacks.utils.test.ts
@@ -1,8 +1,3 @@
-import * as fs from 'fs'
-import * as path from 'path'
-
-import { getTempDir } from './utils.js'
-
 describe('stacks/utils.ts', () => {
   let envOrig: string
   let utils: typeof import('../stacks/utils.js')
@@ -15,31 +10,6 @@ describe('stacks/utils.ts', () => {
 
   afterEach(() => {
     process.env = JSON.parse(envOrig)
-  })
-
-  it('getEnvironment (without process.env)', () => {
-    const tmpDir = getTempDir()
-    const data = 'MOCK=mymock'
-
-    fs.writeFileSync(path.join(tmpDir, '.env'), data)
-
-    const environment = utils.getEnvironment(tmpDir)
-    expect(environment.parsed).toEqual({ MOCK: 'mymock' })
-
-    fs.rmSync(tmpDir, { recursive: true, force: true })
-  })
-
-  it('getEnvironment (with process.env)', () => {
-    process.env['MOCK'] = 'anothermock'
-    const tmpDir = getTempDir()
-    const data = 'MOCK=mymock'
-
-    fs.writeFileSync(path.join(tmpDir, '.env'), data)
-
-    const environment = utils.getEnvironment(tmpDir)
-    expect(environment.parsed).toEqual({ MOCK: 'anothermock' })
-
-    fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
   it('NameRegister.registerName', () => {


### PR DESCRIPTION
+ Static variables are injected at build time by Vite.
+ dotenv and lodash are no longer required.