### PR TITLE
feat: Add option to set Cloudfront managed cache policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ features are as follows:
 export interface AWSAdapterProps {
   artifactPath?: string // Build output directory (default: build)
   autoDeploy?: boolean // Should automatically deploy in SvelteKit build step (default: false)
+  cachePolicy?: string // Cloudfront managed cache policy (default: 'Managed-CachingOptimized')
   defaultHeaders?: string[] // Default whitelist of headers for the SSR server. (default: ['Accept','Accept-Language','If-None-Match','Host','Origin','Referer','X-Forwarded-Host'])
-  extraHeaders?: string[] // Additional headers to add to whitelist. (default: [])
   esbuildOptions?: any // Override or extend default esbuild options for the SSR server. Supports `external` (default `['node:*']`), `format` (default `cjs`), `target` (default `node18`), `banner` (default `{}`).
+  extraHeaders?: string[] // Additional headers to add to whitelist. (default: [])
   FQDN?: string // Full qualified domain name of CloudFront deployment (e.g. demo.example.com)
   memorySize?: number // Memory size of SSR lambda in MB (default: 128)
-  pulumiPaths: string[] // For internal use only
   region?: string // Region to deploy resources (default: us-east-2)
   serverStreaming?: boolean // Use lambda streaming responses for SSR server (default: false)
   stackName?: string // Pulumi stack name (default: dev)
@@ -118,7 +118,7 @@ in the SvelteKit documentation for further details.
 A script is provided to destroy the infrastructure, with the following
 signature:
 
-```
+```console
 adapter-stack-destroy [artifactPath]
 
 Destroy the SvelteKit adapter's Pulumi stacks

--- a/stacks/main/index.ts
+++ b/stacks/main/index.ts
@@ -42,9 +42,9 @@ const distribution = buildCDN(
   routerHandler,
   bucket,
   serverHeaders,
-  cachePolicy,
   FQDN,
   certificateArn,
+  cachePolicy,
 )
 
 if (FQDN) {

--- a/stacks/main/index.ts
+++ b/stacks/main/index.ts
@@ -11,13 +11,14 @@ import {
 } from './resources.js'
 
 const pulumiConfig = new pulumi.Config()
+const cachePolicy = pulumiConfig.require('cachePolicy')
 const edgePath = pulumiConfig.require('edgePath')
-const staticPath = pulumiConfig.require('staticPath')
+const FQDN = pulumiConfig.get('FQDN')
+const optionsArn = pulumiConfig.require('optionsArn')
 const prerenderedPath = pulumiConfig.require('prerenderedPath')
 const serverArn = pulumiConfig.require('serverArn')
-const optionsArn = pulumiConfig.require('optionsArn')
-const FQDN = pulumiConfig.get('FQDN')
 const serverHeadersStr = pulumiConfig.get('serverHeaders')
+const staticPath = pulumiConfig.require('staticPath')
 
 let serverHeaders: string[] = []
 
@@ -41,6 +42,7 @@ const distribution = buildCDN(
   routerHandler,
   bucket,
   serverHeaders,
+  cachePolicy,
   FQDN,
   certificateArn,
 )

--- a/stacks/main/resources.ts
+++ b/stacks/main/resources.ts
@@ -211,6 +211,7 @@ export function buildCDN(
   routerFunction: aws.lambda.Function,
   bucket: aws.s3.Bucket,
   serverHeaders: string[],
+  cachePolicy: string,
   FQDN?: string,
   certificateArn?: pulumi.Input<string>,
 ): aws.cloudfront.Distribution {
@@ -244,7 +245,7 @@ export function buildCDN(
   )
 
   const optimizedCachePolicy = aws.cloudfront.getCachePolicyOutput({
-    name: 'Managed-CachingOptimized',
+    name: cachePolicy,
   })
 
   const distribution = new aws.cloudfront.Distribution(

--- a/stacks/main/resources.ts
+++ b/stacks/main/resources.ts
@@ -211,9 +211,9 @@ export function buildCDN(
   routerFunction: aws.lambda.Function,
   bucket: aws.s3.Bucket,
   serverHeaders: string[],
-  cachePolicy: string,
   FQDN?: string,
   certificateArn?: pulumi.Input<string>,
+  cachePolicy: string = 'Managed-CachingOptimized',
 ): aws.cloudfront.Distribution {
   const defaultRequestPolicy = new aws.cloudfront.OriginRequestPolicy(
     registerName('DefaultRequestPolicy'),

--- a/tests/stacks.main.resources.test.ts
+++ b/tests/stacks.main.resources.test.ts
@@ -146,9 +146,7 @@ describe('stacks/main/resources.ts', () => {
       role: 'mock',
     })
     const bucket = new aws.s3.Bucket('MockBucket')
-    const routes = ['mock/*', 'another/*']
     const serverHeaders = ['mock1', 'mock2']
-    const staticHeaders = ['mock3']
     const FQDN = 'server.example.com'
     const certificateArn = 'MockCertificateArn'
     const bucketId = await promiseOf(bucket.id)


### PR DESCRIPTION
The cachePolicy argument can now be used to customize the cloudfront cache policy using one of the managed policies. It defaults to the previous fixed value of 'Managed-CachingOptimized'.